### PR TITLE
Ignore file sections

### DIFF
--- a/supportconfig.go
+++ b/supportconfig.go
@@ -80,7 +80,7 @@ section:
 
 						}
 						return err
-					} else {
+					} else if collector != nil {
 						collectors = append(collectors, collector)
 					}
 				}
@@ -163,6 +163,10 @@ func (s *Splitter) handler(section, afterline string) (io.WriteCloser, error) {
 		dest, err = s.Config.PathHandler(origDest)
 		if err != nil {
 			return nil, err
+		} else if dest == "" {
+			// If the path handler function return empty string,
+			// the user wants to ignore this section
+			return nil, nil
 		}
 	} else {
 		dest = origDest


### PR DESCRIPTION
There are some supportconfig files sections which are grep commands in
some files in the file system. As these files will be present after the
split of all the supportconfig files we can ignore such sections. Thus,
this commit allows the user of the go-supportconfig library to tell the
splitter which section should be ignored. For that, the user can return
a empty string in the path handler function. The go-supportconfig
library will skip that section.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>